### PR TITLE
Refactor and move useLocalStorageState Hook

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState } from 'react'
 import './styles/app.css'
 import RenderImage from './components/RenderImage'
 import RenderList from './components/RenderList'
@@ -6,28 +6,12 @@ import RenderFilteredList from './components/RenderFilteredList'
 import Counter from './components/Counter'
 import InitialCountForm from './components/InitialCountForm'
 import AddListItemForm from './components/AddListItemForm'
+import { useLocalStorageState } from './utils/useLocalStorageState'
 
 const App = () => {
   const [shoulddisplayimage, setshoulddisplayimage] = useState('true')
-  const [items, setItems] = useState(
-    () => JSON.parse(window.localStorage.getItem('items')) || []
-  )
-  const [count, setCount] = useState(
-    () => parseInt(window.localStorage.getItem('count')) || 0
-  )
-
-  function useLocalStorageState(stateItem) {
-    typeof stateItem === 'object'
-      ? useEffect(() => {
-          window.localStorage.setItem('items', JSON.stringify(stateItem))
-        }, [stateItem])
-      : useEffect(() => {
-          window.localStorage.setItem('count', stateItem)
-        }, [stateItem])
-  }
-
-  useLocalStorageState(count)
-  useLocalStorageState(items)
+  const [items, setItems] = useLocalStorageState('items', [])
+  const [count, setCount] = useLocalStorageState('count', 0)
 
   const addListItem = item => {
     let itemsCopy = [...items]

--- a/src/utils/useLocalStorageState.js
+++ b/src/utils/useLocalStorageState.js
@@ -1,0 +1,29 @@
+import { useState, useEffect, useRef } from 'react'
+
+function useLocalStorageState(
+  key,
+  defaultValue,
+  { serialize = JSON.stringify, deserialize = JSON.parse } = {}
+) {
+  const [state, setState] = useState(() => {
+    const valueInLocalStorage = window.localStorage.getItem(key)
+    if (valueInLocalStorage) {
+      return deserialize(valueInLocalStorage)
+    }
+    return typeof defaultValue === 'function' ? defaultValue() : defaultValue
+  })
+
+  const prevKeyRef = useRef(key)
+
+  useEffect(() => {
+    const prevKey = prevKeyRef.current
+    if (prevKey !== key) {
+      window.localStorage.removeItem(prevKey)
+    }
+    prevKeyRef.current = key
+    window.localStorage.setItem(key, serialize(state))
+  }, [key, state, serialize])
+  return [state, setState]
+}
+
+export { useLocalStorageState }


### PR DESCRIPTION
Adheres to DRY programming principles. Devs can now import and use persistent state from any component.

-refactor useLocalStorageState hook to take in any data type, set the state, and persist the data in localStorage
-add utils/ directory
-refactor App.js to call useLocalStorageState hook